### PR TITLE
Implement play/pause logic in main GUI

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -1079,6 +1079,18 @@ class VoicesAutomationApp:
             self.cancel_button.config(state=tk.DISABLED)
             self.is_paused = False
 
+    def play_pause(self):
+        with self.process_lock:
+            proc = self.process
+        if not proc or proc.poll() is not None:
+            self.run_automation()
+            try:
+                self.apply_controls_state(running=True)
+            except Exception:
+                pass
+        else:
+            self.toggle_pause()
+
     def _walk_children(self, psutil_proc):
         try:
             for child in psutil_proc.children(recursive=True):


### PR DESCRIPTION
## Summary
- add `play_pause` method to start automation when idle or toggle pause when running

## Testing
- `python -m py_compile main_gui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c5aa2b80bc832789501417fd18127d