### PR TITLE
Refine toggle pause control

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -1144,18 +1144,9 @@ class VoicesAutomationApp:
                 self.is_paused = False
                 self.pause_button.config(text="⏸ Pause")
                 self.update_console("[i] Resumed.\n")
-
-            # Ensure run and cancel buttons stay consistent while toggling
-            try:
-                self.play_pause_button.config(state=tk.DISABLED)
-            except Exception:
-                pass
-            try:
-                self.cancel_button.config(state=tk.NORMAL)
-            except Exception:
-                pass
         except Exception as e:
             self.update_console(f"[x] Pause/Resume error: {e}\n")
+        self.apply_controls_state(running=True)
 
     def cancel_run(self):
         with self.process_lock:


### PR DESCRIPTION
## Summary
- simplify `toggle_pause` to only update pause button text and delegate control state refresh to `apply_controls_state`

## Testing
- `python -m py_compile main_gui.py`


------
https://chatgpt.com/codex/tasks/task_b_68c5ac431e2883279fd6385c5fadd754