### PR TITLE
feat: allow window resizing

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -19,9 +19,10 @@ class VoicesAutomationApp:
     def __init__(self, master):
         self.master = master
         master.title("Voices Helper")
-        master.geometry("680x520")
+        master.geometry("800x600")
+        master.minsize(800, 600)
         try:
-            master.resizable(False, False)
+            master.resizable(True, True)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- allow window to open at 800x600 and be resizable
- enforce a minimum window size of 800x600

## Testing
- `python -m py_compile main_gui.py`
- `xvfb-run -a python - <<'PY'
import tkinter as tk
import main_gui
root = tk.Tk()
app = main_gui.VoicesAutomationApp(root)
root.update_idletasks()
# first resize
root.geometry('1000x800')
root.update_idletasks()
slaves = root.pack_slaves()
print('after 1000x800:')
for s in slaves:
    print('child', s, 'y', s.winfo_y(), 'height', s.winfo_height())
# second resize
root.geometry('1200x900')
root.update_idletasks()
slaves = root.pack_slaves()
print('after 1200x900:')
for s in slaves:
    print('child', s, 'y', s.winfo_y(), 'height', s.winfo_height())
root.destroy()
PY`

------
https://chatgpt.com/codex/tasks/task_b_68c5b3ab19f883279018211c1fb36a38