### PR TITLE
Log dropdown state before choosing job

### DIFF
--- a/invite_to_job.py
+++ b/invite_to_job.py
@@ -255,7 +255,21 @@ async def select_job_in_modal(page: Page, job_query: str) -> bool:
         await asyncio.sleep(AFTER_CHOICES_OPEN/1000)
 
         dropdown = modal.locator(CHOICES_DROPDOWN).first
-        await dropdown.wait_for(state="visible", timeout=6000)
+        aria = await dropdown.get_attribute("aria-expanded")
+        info(f"Dropdown aria-expanded after click: {aria}")
+
+        try:
+            await modal.locator(f"{CHOICES_DROPDOWN}[aria-expanded='true']").wait_for(state="visible", timeout=6000)
+        except PWTimeout:
+            warn("Dropdown did not open (aria-expanded!='true'). Capturing screenshot…")
+            os.makedirs("logs", exist_ok=True)
+            try:
+                await page.screenshot(path="logs/dropdown_not_open.png")
+            except Exception:
+                pass
+            raise
+
+        dropdown = modal.locator(f"{CHOICES_DROPDOWN}[aria-expanded='true']").first
 
         options = dropdown.locator(CHOICES_ITEMS)
         count = await options.count()

--- a/invite_to_job_cdp.py
+++ b/invite_to_job_cdp.py
@@ -137,6 +137,20 @@ async def select_job_in_modal(page: Page, job_query: Optional[str]) -> bool:
         await choices_container.wait_for(state="visible", timeout=DEFAULT_TIMEOUT_MS)
         await inner.click()
         await asyncio.sleep(0.25)
+
+        dropdown = modal.locator(CHOICES_DROPDOWN).first
+        aria = await dropdown.get_attribute("aria-expanded")
+        info(f"Dropdown aria-expanded after click: {aria}")
+        try:
+            await modal.locator(f"{CHOICES_DROPDOWN}[aria-expanded='true']").wait_for(state="visible", timeout=5000)
+        except PWTimeout:
+            warn("Dropdown did not open (aria-expanded!='true'). Capturing screenshot…")
+            os.makedirs("logs", exist_ok=True)
+            try:
+                await page.screenshot(path="logs/dropdown_not_open.png")
+            except Exception:
+                pass
+            raise
     except Exception:
         warn("Choices.js dropdown not found; trying native select fallback")
         if job_id:


### PR DESCRIPTION
## Summary
- Log `aria-expanded` for Choices.js dropdown and wait for `[aria-expanded='true']`
- Capture screenshot when dropdown fails to open
- Maintain option listing only after dropdown is confirmed open

## Testing
- `python -m py_compile invite_to_job.py invite_to_job_cdp.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6c7fd491c8327adae44c3789a710e