### PR TITLE
Sanitize job number before importing invites

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -1053,7 +1053,12 @@ class VoicesAutomationApp:
         if not job_val:
             messagebox.showwarning("Job # Required", "Enter the Job # to invite talents to. Example: 805775")
             return
-        env['JOB_QUERY'] = job_val
+        sanitized_job_val = re.sub(r"\D", "", job_val)
+        if not sanitized_job_val:
+            messagebox.showwarning("Job # Required", "Job # must contain digits. Example: 805775")
+            return
+        self._import_job_number = sanitized_job_val
+        env['JOB_QUERY'] = sanitized_job_val
 
         # Loop each username and invite via profile URL
         self._stop_import = False


### PR DESCRIPTION
## Summary
- Strip non-digit characters from user-entered job number when importing invites
- Warn when the sanitized job number is empty

## Testing
- `python -m py_compile main_gui.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_b_68c6cef0038c83278678c2f0be089147