### PR TITLE
Add guidance label for invite and favorites modes

### DIFF
--- a/gui/widgets.py
+++ b/gui/widgets.py
@@ -386,6 +386,20 @@ class WidgetMixin:
         except Exception:
             pass
 
+        if action in {"invite", "favorites"}:
+            helper_label = ttk.Label(
+                self.input_frame,
+                text="Open the relevant Voices page, then click Start.",
+                anchor="center",
+                justify=tk.CENTER,
+                wraplength=360,
+            )
+            self._style_label(helper_label)
+            helper_label.pack(
+                fill=tk.X,
+                padx=self.spacing["inline"],
+                pady=(self.spacing["row"], 0),
+            )
         if action == "invite":
             pass
         elif action == "favorites":


### PR DESCRIPTION
## Summary
- add an instructional label when the invite or favorites action is selected so users know to prep the Voices page
- style the label with the existing helper to match the rest of the UI

## Testing
- python -m compileall gui/widgets.py

------
https://chatgpt.com/codex/tasks/task_b_68c8bf2bfce08327b55b5c7cd763d831